### PR TITLE
Uses BigInt 3.0.0

### DIFF
--- a/SwiftySRP.podspec
+++ b/SwiftySRP.podspec
@@ -7,12 +7,12 @@ Pod::Spec.new do |spec|
     spec.homepage     = 'https://github.com/serieuxchat/SwiftySRP'
     spec.author       = 'Sergey Novitsky'
     spec.source       = { :git => 'https://github.com/serieuxchat/SwiftySRP.git', :tag => 'v' + String(spec.version) }
-    spec.source_files = 'SwiftySRP/*.swift', 'imath/*.{c,h}', 
+    spec.source_files = 'SwiftySRP/*.swift', 'imath/*.{c,h}',
 	spec.public_header_files = 'SwiftySRP/*.h'
     spec.documentation_url = 'https://github.com/serieuxchat/SwiftySRP/'
-    spec.dependency 'BigInt', '~> 2.2.0'
+    spec.dependency 'BigInt', '~> 3.0.0'
     spec.preserve_paths = 'CommonCrypto/module.modulemap', 'imath/**', 'README', 'SwiftySRPTests/*.swift'
-    
+
     # Things are listed twice (with different paths) in order to also make it compile as a development pod.
     spec.xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(PODS_ROOT)/SwiftySRP/CommonCrypto $(PODS_ROOT)/SwiftySRP/imath $(SRCROOT)/../CommonCrypto $(SRCROOT)/../imath' }
 end


### PR DESCRIPTION
This PR fixes the following error when executing `pod install` in the `swift4` branch

```
[!] Unable to satisfy the following requirements:

- `BigInt (from `https://github.com/lorentey/BigInt.git`, branch `swift4`)` required by `Podfile`
- `BigInt (from `https://github.com/lorentey/BigInt.git`, branch `swift4`)` required by `Podfile`
- `BigInt (from `https://github.com/lorentey/BigInt.git`, branch `swift4`)` required by `Podfile`
- `BigInt (from `https://github.com/lorentey/BigInt.git`, branch `swift4`)` required by `Podfile`
- `BigInt (from `https://github.com/lorentey/BigInt.git`, branch `swift4`)` required by `Podfile`
- `BigInt (from `https://github.com/lorentey/BigInt.git`, branch `swift4`)` required by `Podfile`
- `BigInt (~> 2.2.0)` required by `SwiftySRP (1.2)`
```
